### PR TITLE
Add pre-commit to IAC Docker image

### DIFF
--- a/docker/iac/Dockerfile
+++ b/docker/iac/Dockerfile
@@ -84,6 +84,8 @@ RUN apt-get update && \
     # Install Ansible
     pipx install --include-deps ansible-dev-tools==${ANSIBLE_DEV_TOOLS_VERSION} && \
     pipx inject ansible-dev-tools pywinrm[kerberos] && \
+    # Install pre-commit
+    pipx install pre-commit && \
     # Remove wget (no longer needed after setup)
     apt-get purge -y --auto-remove wget && \
     # Clean up package caches and temporary files


### PR DESCRIPTION
## Summary
Adds pre-commit framework to the IAC Docker image to enable automated code quality checks and pre-commit hooks.

## Changes
- Install pre-commit using pipx for isolated installation
- Maintains single RUN layer optimization to keep image size minimal
- Pre-commit is installed globally and accessible via PIPX_BIN_DIR

## Benefits
- Enables automated code quality checks before commits
- Supports various hooks for linting, formatting, and validation
- Improves code consistency across the team

## Testing
- Pre-commit will be available in the container at /usr/local/bin/pre-commit
- Can be verified with: `pre-commit --version`
